### PR TITLE
Make client command more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,23 @@ docker run -d --name burp-client \
 ```
 
 Once this container is created, it will backup the specified data and exit. After that, it's recommended to start the container ~ every 20 minutes with `docker start burp-client`, so it can check with the server and backup new files if scheduled. The schedule is determined by the server, not the client.
+
+### Data recovery
+
+You may also use it to recover data from a distant server.
+You just have to provide arguments as you would to a regular burp client CLI.
+
+for example:
+
+```
+docker run -d --name burp-client \
+  -e BURP_SERVER=some-server.host \
+  -e BURP_CLIENT_PASSWORD=super-secret \
+  -v burp-client-conf:/etc/burp \
+  -v /etc:/tobackup/somehost-etc \
+  --hostname $HOSTNAME \
+  --security-opt label:disable \
+  pschiffe/burp-client \
+  -al /tobackup/somehost-etc
+```
+

--- a/burp-client/Dockerfile
+++ b/burp-client/Dockerfile
@@ -19,4 +19,5 @@ VOLUME [ "/etc/burp" ]
 COPY burp.conf.tpl /etc/burp/burp.conf.tpl
 COPY docker-cmd.sh /docker-cmd.sh
 
-CMD [ "/docker-cmd.sh" ]
+ENTRYPOINT [ "/docker-cmd.sh" ]
+CMD [ "-a", "t" ]

--- a/burp-client/docker-cmd.sh
+++ b/burp-client/docker-cmd.sh
@@ -11,4 +11,4 @@ envsubst < /etc/burp/burp.conf.tpl > /etc/burp/burp.conf
 
 wait-for-it.sh "${BURP_SERVER}:${BURP_SERVER_PORT}"
 
-exec /usr/sbin/burp -a t
+exec /usr/sbin/burp $*


### PR DESCRIPTION
Instead of just using the `CMD` directive in Dockerfile, we can use an `ENTRYPOINT` and a `CMD` directives, to separate program and arguments.

In such a way the docker-image can be used as the regular burp CLI to list backups or restore them.